### PR TITLE
Change KorQuAD v2.0 dataset path to official distribution

### DIFF
--- a/thunderllm/inference/tasks/thunderllm-benchmark/korquad/thunderllm-korquadv2_1.yaml
+++ b/thunderllm/inference/tasks/thunderllm-benchmark/korquad/thunderllm-korquadv2_1.yaml
@@ -1,6 +1,6 @@
 task: thunderllm-korquadv2_1
 class: !function task.Korquad
-dataset_path: kmgme/KorQuADv2_1
+dataset_path: LGCNS/KorQuAD_2.0
 dataset_kwargs:
   trust_remote_code: true
 training_split: train


### PR DESCRIPTION
At the distribution time of our code, LG CNS did not provide official huggingface distribution of KorQuAD dataset. As they uploaded the official distributios, we change dataset path to the official distribution.